### PR TITLE
feat: basic go webserver for vps deployment

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,0 +1,17 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+)
+
+func main() {
+	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintf(w, "Hallo! Dieser Go-Server nutzt Port 9001 und läuft stabil auf dem VPS!")
+	})
+
+	// Port 9001 für VPS
+	port := ":9001"
+	fmt.Println("Go-App startet auf Port", port)
+	http.ListenAndServe(port, nil)
+}


### PR DESCRIPTION
### Implementiert einen Go-Server auf Port 9001. Vorbereitet für das Deployment auf dem VPS unter der Subdomain go-vps

Closes #1