### PR TITLE
Initialize Go Module

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module go-vps-backend-container
+
+go 1.21


### PR DESCRIPTION
Fügt die notwendige go.mod Datei hinzu, um den Build-Fehler im Container zu beheben.

Closes #5